### PR TITLE
join users and category tables to /post request

### DIFF
--- a/loaddata.sql
+++ b/loaddata.sql
@@ -112,3 +112,20 @@ INSERT INTO Reactions ('label', 'image_url') VALUES ('like', 'https://www.pngfin
 INSERT INTO Reactions ('label', 'image_url') VALUES ('love', 'https://www.clipartmax.com/png/middle/124-1245735_heart-emoji-transparent-background.png');
 INSERT INTO Reactions ('label', 'image_url') VALUES ('sad', 'https://toppng.com/uploads/preview/sad-face-transparent-png-crying-emoji-transparent-background-11562873850hiicomfwuq.png');
 INSERT INTO Reactions ('label', 'image_url') VALUES ('wow', 'https://e1.pngegg.com/pngimages/477/616/png-clipart-emoji-sticker-wow-emoji-illustration-thumbnail.png');
+
+
+
+  SELECT
+                p.id,
+                p.user_id,
+                p.category_id,
+                p.title,
+                p.publication_date,
+                p.image_url,
+                p.content,
+                p.approved,
+                u.first_name first_name,
+                u.last_name last_name
+            FROM Posts p
+            JOIN Users u
+                ON u.id = p.user_id

--- a/models/post.py
+++ b/models/post.py
@@ -1,5 +1,6 @@
 class Post():
     """Class initializer to create post objects"""
+
     def __init__(self, id, user_id, category_id, title, publication_date, image_url, content, approved):
         self.id = id
         self.user_id = user_id
@@ -9,3 +10,5 @@ class Post():
         self.image_url = image_url
         self.content = content
         self.approved = approved
+        self.author = None
+        self.category = None

--- a/models/user.py
+++ b/models/user.py
@@ -1,6 +1,7 @@
 class User():
     """Class initializer to create user objects"""
-    def __init__(self, id, first_name, last_name, email, bio, username, password, profile_image_url, created_on, active):
+
+    def __init__(self, id, first_name, last_name, email="", bio="", username="", password="", profile_image_url="", created_on="", active="ß"):
         self.id = id
         self.first_name = first_name
         self.last_name = last_name

--- a/views/repository.py
+++ b/views/repository.py
@@ -85,6 +85,7 @@ def all(resource):
                 ON u.id = p.user_id
             JOIN Categories c 
                 ON c.id = p.category_id
+                ORDER BY p.publication_date DESC;
             """)
 
             # Initialize an empty list to hold all post representations


### PR DESCRIPTION
# Description 

Joined users and categories tables to /posts response when client requests all posts so that client can see the author's first and last name, and the category of a post.
Altered users.py in models, to initialize keys to empty strings. 

# Steps to Test
1. Fetch nick-all-posts and switch to it
2. Start server in debugger mode
3. Open postman and make a request to /posts
4. Verify the response contains both Users and Categories embedded 
5. Verify in Users key, only First_name and last_name keys have values, and the rest empty strings

@jesmeeker @MaeYoungPhan @lauren-hanson @JLinkous15 