### PR TITLE
updated get all tags to order by label ASC

### DIFF
--- a/views/repository.py
+++ b/views/repository.py
@@ -43,6 +43,7 @@ def all(resource):
                 t.id,
                 t.label
             FROM tags t
+            ORDER By t.label ASC
             """)
 
             # Initialize an empty list to hold all tag representations


### PR DESCRIPTION
Closes # 21

# Description: 

Updated logic in all function in repository.py to order by label asc when resource = 'tags' is requested by client

# Steps to Test:
1. Fetch branch [get-alltags-by-labelASC-MP](https://github.com/nss-day-cohort-60/rare-python-server-tyrannical-tators/compare/main...get-all-tags-by-labelASC-MP?expand=1) and start your debugger
2. Open postman
3. GET http://localhost:8088/tags
4. A list of all tags should be returned ordered by ASC